### PR TITLE
Freeze twig dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "twig/twig": "dev-master"
+        "twig/twig": ">=1.1, <2.0-dev"
     },
     "autoload": {
         "psr-0": { "TwigGenerator": "src/" }


### PR DESCRIPTION
Best practice with composer and ease integration with others dependencies like twig bridge.
