### PR TITLE
Make tempDir configurable

### DIFF
--- a/src/TwigGenerator/Builder/Generator.php
+++ b/src/TwigGenerator/Builder/Generator.php
@@ -51,10 +51,16 @@ class Generator
 
     /**
      * Init a new generator and automatically define the base of temp directory.
+     * 
+     * @param string $baseTempDir    Existing base directory for temporary template files
      */
-    public function __construct()
+    public function __construct($baseTempDir = null)
     {
-        $this->tempDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.self::TEMP_DIR_PREFIX;
+        if (null === $baseTempDir) {
+            $baseTempDir = sys_get_temp_dir();
+        }
+
+        $this->tempDir = realpath($baseTempDir).DIRECTORY_SEPARATOR.self::TEMP_DIR_PREFIX;
 
         if (!is_dir($this->tempDir)) {
             mkdir($this->tempDir, 0777, true);


### PR DESCRIPTION
I think using sys_get_temp_dir() as temporary directory is a really bad idea, since it breaks when using open_basedir or otherwise strict file access and can lead to collisions when several projects with similar template names are sharing a server.

After this patch is included the next step would be setting the same option in the AdmingeneratorGeneratorBundle to use the Sf2 cache dir.
